### PR TITLE
merge develop

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,7 @@
 - Fix: serialization of Units without a value, see #1240.
 - Fix: outdated, incorrect documentation about the order of precedence for
   operator modulus `%`. See #3189.
+- Fix: #3197 improve `quantileSeq` type definitions (#3198). Thanks @domdomegg.
 
 
 # 2024-04-24, 12.4.2

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,8 @@
 # unpublished changes since 12.4.2
 
 - Fix: serialization of Units without a value, see #1240.
+- Fix: outdated, incorrect documentation about the order of precedence for
+  operator modulus `%`. See #3189.
 
 
 # 2024-04-24, 12.4.2

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,10 @@
 # History
 
+# unpublished changes since 12.4.2
+
+- Fix: serialization of Units without a value, see #1240.
+
+
 # 2024-04-24, 12.4.2
 
 - Fix #3192: function `isNaN` returns `false` for `NaN` units in a matrix or

--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ Then, the tests can be executed:
 
     npm test
 
+To test the type definitions:
+
+    npm run test:types
+
 Additionally, the tests can be run on FireFox using [headless mode](https://developer.mozilla.org/en-US/Firefox/Headless_mode):
 
     npm run test:browser

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -113,7 +113,7 @@ function completer (text) {
     const ignore = ['expr', 'type']
     for (const func in math.expression.mathWithTransform) {
       if (hasOwnProperty(math.expression.mathWithTransform, func)) {
-        if (func.indexOf(keyword) === 0 && ignore.indexOf(func) === -1) {
+        if (func.indexOf(keyword) === 0 && !ignore.includes(func)) {
           matches.push(func)
         }
       }

--- a/docs/expressions/syntax.md
+++ b/docs/expressions/syntax.md
@@ -114,8 +114,9 @@ Operators                         | Description
 `!`                               | Factorial
 `^`, `.^`                         | Exponentiation
 `+`, `-`, `~`, `not`              | Unary plus, unary minus, bitwise not, logical not
+`%`, `mod`                        | percentage, modulus
 See section below                 | Implicit multiplication
-`*`, `/`, `.*`, `./`, `%`, `mod`  | Multiply, divide, percentage, modulus
+`*`, `/`, `.*`, `./`              | Multiply, divide
 `+`, `-`                          | Add, subtract
 `:`                               | Range
 `to`, `in`                        | Unit conversion

--- a/src/core/function/config.js
+++ b/src/core/function/config.js
@@ -88,23 +88,13 @@ export function configFactory (config, emit) {
 }
 
 /**
- * Test whether an Array contains a specific item.
- * @param {Array.<string>} array
- * @param {string} item
- * @return {boolean}
- */
-function contains (array, item) {
-  return array.indexOf(item) !== -1
-}
-
-/**
  * Validate an option
  * @param {Object} options         Object with options
  * @param {string} name            Name of the option to validate
  * @param {Array.<string>} values  Array with valid values for this option
  */
 function validateOption (options, name, values) {
-  if (options[name] !== undefined && !contains(values, options[name])) {
+  if (options[name] !== undefined && !values.includes(options[name])) {
     // unknown value
     console.warn('Warning: Unknown value "' + options[name] + '" for configuration option "' + name + '". ' +
       'Available options: ' + values.map(value => JSON.stringify(value)).join(', ') + '.')

--- a/src/core/function/import.js
+++ b/src/core/function/import.js
@@ -1,7 +1,6 @@
 import { isBigNumber, isComplex, isFraction, isMatrix, isUnit } from '../../utils/is.js'
 import { isFactory, stripOptionalNotation } from '../../utils/factory.js'
 import { hasOwnProperty, lazy } from '../../utils/object.js'
-import { contains } from '../../utils/array.js'
 import { ArgumentsError } from '../../error/ArgumentsError.js'
 
 export function importFactory (typed, load, math, importedFactories) {
@@ -235,7 +234,7 @@ export function importFactory (typed, load, math, importedFactories) {
    * @private
    */
   function _importFactory (factory, options, name = factory.fn) {
-    if (contains(name, '.')) {
+    if (name.includes('.')) {
       throw new Error('Factory name should not contain a nested path. ' +
         'Name: ' + JSON.stringify(name))
     }
@@ -253,7 +252,7 @@ export function importFactory (typed, load, math, importedFactories) {
       factory.dependencies
         .map(stripOptionalNotation)
         .forEach(dependency => {
-          if (contains(dependency, '.')) {
+          if (dependency.includes('.')) {
             throw new Error('Factory dependency should not contain a nested path. ' +
               'Name: ' + JSON.stringify(dependency))
           }
@@ -353,7 +352,7 @@ export function importFactory (typed, load, math, importedFactories) {
   }
 
   function factoryAllowedInExpressions (factory) {
-    return factory.fn.indexOf('.') === -1 && // FIXME: make checking on path redundant, check on meta data instead
+    return !factory.fn.includes('.') && // FIXME: make checking on path redundant, check on meta data instead
       !hasOwnProperty(unsafe, factory.fn) &&
       (!factory.meta || !factory.meta.isClass)
   }

--- a/src/expression/parse.js
+++ b/src/expression/parse.js
@@ -1024,7 +1024,7 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
   }
 
   /**
-   * multiply, divide, modulus
+   * multiply, divide
    * @return {Node} node
    * @private
    */
@@ -1102,7 +1102,7 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
    * @private
    */
   function parseRule2 (state) {
-    let node = parsePercentage(state)
+    let node = parseModulusPercentage(state)
     let last = node
     const tokenStates = []
 
@@ -1125,7 +1125,7 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
             // Rewind once and build the "number / number" node; the symbol will be consumed later
             Object.assign(state, tokenStates.pop())
             tokenStates.pop()
-            last = parsePercentage(state)
+            last = parseModulusPercentage(state)
             node = new OperatorNode('/', 'divide', [node, last])
           } else {
             // Not a match, so rewind
@@ -1147,11 +1147,11 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
   }
 
   /**
-   * percentage or mod
+   * modulus and percentage
    * @return {Node} node
    * @private
    */
-  function parsePercentage (state) {
+  function parseModulusPercentage (state) {
     let node, name, fn, params
 
     node = parseUnary(state)
@@ -1160,6 +1160,7 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
       '%': 'mod',
       mod: 'mod'
     }
+
     while (hasOwnProperty(operators, state.token)) {
       name = state.token
       fn = operators[name]

--- a/src/expression/parse.js
+++ b/src/expression/parse.js
@@ -1341,7 +1341,7 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
 
       if (hasOwnProperty(CONSTANTS, name)) { // true, false, null, ...
         node = new ConstantNode(CONSTANTS[name])
-      } else if (NUMERIC_CONSTANTS.indexOf(name) !== -1) { // NaN, Infinity
+      } else if (NUMERIC_CONSTANTS.includes(name)) { // NaN, Infinity
         node = new ConstantNode(numeric(name, 'number'))
       } else {
         node = new SymbolNode(name)
@@ -1373,7 +1373,7 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
     let params
 
     while ((state.token === '(' || state.token === '[' || state.token === '.') &&
-        (!types || types.indexOf(state.token) !== -1)) { // eslint-disable-line no-unmodified-loop-condition
+        (!types || types.includes(state.token))) { // eslint-disable-line no-unmodified-loop-condition
       params = []
 
       if (state.token === '(') {

--- a/src/function/algebra/derivative.js
+++ b/src/function/algebra/derivative.js
@@ -172,7 +172,7 @@ export const createDerivative = /* #__PURE__ */ factory(name, dependencies, ({
     },
 
     'Object, FunctionAssignmentNode, string': function (constNodes, node, varName) {
-      if (node.params.indexOf(varName) === -1) {
+      if (!node.params.includes(varName)) {
         constNodes[node] = true
         return true
       }

--- a/src/function/algebra/rationalize.js
+++ b/src/function/algebra/rationalize.js
@@ -252,7 +252,7 @@ export const createRationalize = /* #__PURE__ */ factory(name, dependencies, ({
             recPoly(node.args[0])
           }
         } else {
-          if (oper.indexOf(node.op) === -1) {
+          if (!oper.includes(node.op)) {
             throw new Error('Operator ' + node.op + ' invalid in polynomial expression')
           }
           for (let i = 0; i < node.args.length; i++) {
@@ -536,7 +536,7 @@ export const createRationalize = /* #__PURE__ */ factory(name, dependencies, ({
         throw new Error('There is an unsolved function call')
       } else if (tp === 'OperatorNode') {
         // ***** OperatorName *****
-        if ('+-*^'.indexOf(node.op) === -1) throw new Error('Operator ' + node.op + ' invalid')
+        if (!'+-*^'.includes(node.op)) throw new Error('Operator ' + node.op + ' invalid')
 
         if (noPai !== null) {
           // -(unary),^  : children of *,+,-

--- a/src/function/algebra/simplifyConstant.js
+++ b/src/function/algebra/simplifyConstant.js
@@ -355,7 +355,7 @@ export const createSimplifyConstant = /* #__PURE__ */ factory(name, dependencies
         {
           // Process operators as OperatorNode
           const operatorFunctions = ['add', 'multiply']
-          if (operatorFunctions.indexOf(node.name) === -1) {
+          if (!operatorFunctions.includes(node.name)) {
             const args = node.args.map(arg => foldFraction(arg, options))
 
             // If all args are numbers

--- a/src/function/statistics/mad.js
+++ b/src/function/statistics/mad.js
@@ -53,7 +53,7 @@ export const createMad = /* #__PURE__ */ factory(name, dependencies, ({ typed, a
         return abs(subtract(value, med))
       }))
     } catch (err) {
-      if (err instanceof TypeError && err.message.indexOf('median') !== -1) {
+      if (err instanceof TypeError && err.message.includes('median')) {
         throw new TypeError(err.message.replace('median', 'mad'))
       } else {
         throw improveErrorMessage(err, 'mad')

--- a/src/function/statistics/std.js
+++ b/src/function/statistics/std.js
@@ -88,7 +88,7 @@ export const createStd = /* #__PURE__ */ factory(name, dependencies, ({ typed, m
         return sqrt(v)
       }
     } catch (err) {
-      if (err instanceof TypeError && err.message.indexOf(' variance') !== -1) {
+      if (err instanceof TypeError && err.message.includes(' variance')) {
         throw new TypeError(err.message.replace(' variance', ' std'))
       } else {
         throw err

--- a/src/function/statistics/utils/improveErrorMessage.js
+++ b/src/function/statistics/utils/improveErrorMessage.js
@@ -14,7 +14,7 @@ export function improveErrorMessage (err, fnName, value) {
   // TODO: add information with the index (also needs transform in expression parser)
   let details
 
-  if (String(err).indexOf('Unexpected type') !== -1) {
+  if (String(err).includes('Unexpected type')) {
     details = arguments.length > 2
       ? ' (type: ' + typeOf(value) + ', value: ' + JSON.stringify(value) + ')'
       : ' (type: ' + err.data.actual + ')'
@@ -22,7 +22,7 @@ export function improveErrorMessage (err, fnName, value) {
     return new TypeError('Cannot calculate ' + fnName + ', unexpected type of argument' + details)
   }
 
-  if (String(err).indexOf('complex numbers') !== -1) {
+  if (String(err).includes('complex numbers')) {
     details = arguments.length > 2
       ? ' (type: ' + typeOf(value) + ', value: ' + JSON.stringify(value) + ')'
       : ''

--- a/src/type/unit/Unit.js
+++ b/src/type/unit/Unit.js
@@ -902,7 +902,7 @@ export const createUnitClass = /* #__PURE__ */ factory(name, dependencies, ({
     return {
       mathjs: 'Unit',
       value: this._denormalize(this.value),
-      unit: this.formatUnits(),
+      unit: this.units.length > 0 ? this.formatUnits() : null,
       fixPrefix: this.fixPrefix
     }
   }
@@ -915,7 +915,7 @@ export const createUnitClass = /* #__PURE__ */ factory(name, dependencies, ({
    * @return {Unit}
    */
   Unit.fromJSON = function (json) {
-    const unit = new Unit(json.value, json.unit)
+    const unit = new Unit(json.value, json.unit ?? undefined)
     unit.fixPrefix = json.fixPrefix || false
     return unit
   }

--- a/src/utils/array.js
+++ b/src/utils/array.js
@@ -651,16 +651,6 @@ export function initial (array) {
 }
 
 /**
- * Test whether an array or string contains an item
- * @param {Array | string} array
- * @param {*} item
- * @return {boolean}
- */
-export function contains (array, item) {
-  return array.indexOf(item) !== -1
-}
-
-/**
  * Recursively concatenate two matrices.
  * The contents of the matrices is not cloned.
  * @param {Array} a             Multi dimensional array

--- a/src/utils/bignumber/formatter.js
+++ b/src/utils/bignumber/formatter.js
@@ -201,7 +201,7 @@ export function toEngineering (value, precision) {
   const valueWithoutExp = value.mul(Math.pow(10, -newExp))
 
   let valueStr = valueWithoutExp.toPrecision(precision)
-  if (valueStr.indexOf('e') !== -1) {
+  if (valueStr.includes('e')) {
     const BigNumber = value.constructor
     valueStr = new BigNumber(valueStr).toFixed()
   }

--- a/src/utils/factory.js
+++ b/src/utils/factory.js
@@ -1,4 +1,3 @@
-import { contains } from './array.js'
 import { pickShallow } from './object.js'
 
 /**
@@ -63,7 +62,7 @@ export function sortFactories (factories) {
   function containsDependency (factory, dependency) {
     // TODO: detect circular references
     if (isFactory(factory)) {
-      if (contains(factory.dependencies, dependency.fn || dependency.name)) {
+      if (factory.dependencies.includes(dependency.fn || dependency.name)) {
         return true
       }
 

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -392,5 +392,5 @@ export function pickShallow (object, properties) {
 
 // helper function to test whether a string contains a path like 'user.name'
 function isPath (str) {
-  return str.indexOf('.') !== -1
+  return str.includes('.')
 }

--- a/src/utils/snapshot.js
+++ b/src/utils/snapshot.js
@@ -16,7 +16,7 @@ export function validateBundle (expectedBundleStructure, bundle) {
   const originalWarn = console.warn
 
   console.warn = function (...args) {
-    if (args.join(' ').indexOf('is moved to') !== -1 && args.join(' ').indexOf('Please use the new location instead') !== -1) {
+    if (args.join(' ').includes('is moved to') && args.join(' ').includes('Please use the new location instead')) {
       // Ignore warnings like:
       // Warning: math.type.isNumber is moved to math.isNumber in v6.0.0. Please use the new location instead.
       return
@@ -52,11 +52,11 @@ export function validateBundle (expectedBundleStructure, bundle) {
       const expectedType = get(expectedBundleStructure, path) || 'undefined'
 
       // FIXME: ugly to have these special cases
-      if (path.join('.').indexOf('docs.') !== -1) {
+      if (path.join('.').includes('docs.')) {
         // ignore the contents of docs
         return
       }
-      if (path.join('.').indexOf('all.') !== -1) {
+      if (path.join('.').includes('all.')) {
         // ignore the contents of all dependencies
         return
       }
@@ -237,7 +237,7 @@ export function createSnapshotFromFactories (factories) {
 
 function traverse (obj, callback = (value, path) => {}, path = []) {
   // FIXME: ugly to have these special cases
-  if (path.length > 0 && path[0].indexOf('Dependencies') !== -1) {
+  if (path.length > 0 && path[0].includes('Dependencies')) {
     // special case for objects holding a collection of dependencies
     callback(obj, path)
   } else if (validateTypeOf(obj) === 'Array') {

--- a/test/node-tests/browser.test.js
+++ b/test/node-tests/browser.test.js
@@ -22,7 +22,7 @@ describe('lib/browser', function () {
     // don't output all warnings "math.foo.bar is move to math.bar, ..."
     const originalWarn = console.warn
     console.warn = (...args) => {
-      if (args.join(' ').indexOf('is moved to') === -1) {
+      if (!args.join(' ').includes('is moved to')) {
         originalWarn.apply(console, args)
       }
     }
@@ -85,7 +85,7 @@ describe('lib/browser', function () {
       const obj = math[prop]
       if (math.typeOf(obj) !== 'Object') {
         try {
-          if (ignore.indexOf(prop) === -1) {
+          if (!ignore.includes(prop)) {
             math.help(prop).toString()
           }
         } catch (err) {

--- a/test/node-tests/doc.test.js
+++ b/test/node-tests/doc.test.js
@@ -5,7 +5,7 @@ const approx = require('../../tools/approx.js')
 const docgenerator = require('../../tools/docgenerator.js')
 const math = require('../..')
 
-const debug = process.argv.indexOf('--debug-docs') !== -1
+const debug = process.argv.includes('--debug-docs')
 
 function extractExpectation (comment, optional = false) {
   if (comment === '') return undefined

--- a/test/typescript-tests/testTypes.ts
+++ b/test/typescript-tests/testTypes.ts
@@ -2454,7 +2454,7 @@ MathNode examples
 }
 
 /*
-min/max return types
+Statistics functions' return types
 */
 {
   const math = create(all, {})
@@ -2526,6 +2526,18 @@ min/max return types
   expectTypeOf(math.median(123, math.bignumber('456'))).toMatchTypeOf<
     number | BigNumber | Fraction | Complex | Unit
   >()
+
+  expectTypeOf(math.quantileSeq([1, 2, 3], 0.75)).toMatchTypeOf<number>()
+  expectTypeOf(math.quantileSeq([[1, 2, 3]], 0.75)).toMatchTypeOf<number>()
+  expectTypeOf(
+    math.quantileSeq([math.bignumber('123')], 0.75)
+  ).toMatchTypeOf<BigNumber>()
+  expectTypeOf(math.quantileSeq(math.matrix([1, 2, 3]), 0.75)).toMatchTypeOf<
+    MathScalarType | MathArray
+  >()
+  expectTypeOf(
+    math.quantileSeq([math.unit('5cm'), math.unit('10cm')], 0.75)
+  ).toMatchTypeOf<Unit>()
 }
 
 /*

--- a/test/unit-tests/json/replacer.test.js
+++ b/test/unit-tests/json/replacer.test.js
@@ -72,6 +72,20 @@ describe('replacer', function () {
     assert.deepStrictEqual(JSON.stringify(u, replacer), json)
   })
 
+  it('should stringify a Unit with a value only', function () {
+    const u = new math.Unit(5)
+    const json = '{"mathjs":"Unit","value":5,"unit":null,"fixPrefix":false}'
+    assert.deepStrictEqual(JSON.stringify(u), json)
+    assert.deepStrictEqual(JSON.stringify(u, replacer), json)
+  })
+
+  it('should stringify a Unit without a value', function () {
+    const u = new math.Unit(null, 'cm')
+    const json = '{"mathjs":"Unit","value":null,"unit":"cm","fixPrefix":false}'
+    assert.deepStrictEqual(JSON.stringify(u), json)
+    assert.deepStrictEqual(JSON.stringify(u, replacer), json)
+  })
+
   it('should stringify a Matrix, dense', function () {
     const m = math.matrix([[1, 2], [3, 4]], 'dense')
     const json = '{"mathjs":"DenseMatrix","data":[[1,2],[3,4]],"size":[2,2]}'

--- a/test/unit-tests/json/reviver.test.js
+++ b/test/unit-tests/json/reviver.test.js
@@ -70,6 +70,26 @@ describe('reviver', function () {
     assert.deepStrictEqual(obj, u)
   })
 
+  it('should parse a stringified Unit with a value only', function () {
+    const json = '{"mathjs":"Unit","value":5,"unit":null,"fixPrefix":false}'
+    const u = new math.Unit(5)
+
+    const obj = JSON.parse(json, reviver)
+
+    assert(obj instanceof math.Unit)
+    assert.deepStrictEqual(obj, u)
+  })
+
+  it('should parse a stringified Unit without a value', function () {
+    const json = '{"mathjs":"Unit","value":null,"unit":"cm","fixPrefix":false}'
+    const u = new math.Unit(null, 'cm')
+
+    const obj = JSON.parse(json, reviver)
+
+    assert(obj instanceof math.Unit)
+    assert.deepStrictEqual(obj, u)
+  })
+
   it('should parse a stringified Range (2)', function () {
     const json = '{"mathjs":"Range","start":2,"end":10,"step":2}'
     const r = new math.Range(2, 10, 2)

--- a/test/unit-tests/type/matrix/utils/deepForEach.test.js
+++ b/test/unit-tests/type/matrix/utils/deepForEach.test.js
@@ -1,1 +1,63 @@
-// TODO: test deepForEach
+import assert from 'assert'
+import math from '../../../../../src/defaultInstance.js'
+import { deepForEach } from '../../../../../src/utils/collection.js'
+
+const DenseMatrix = math.DenseMatrix
+
+describe('deepForEach', function () {
+  it('should iterate over all elements in a simple array', function () {
+    const array = [1, 2, 3]
+    const result = []
+    deepForEach(array, value => result.push(value))
+    assert.deepStrictEqual(result, [1, 2, 3])
+  })
+
+  it('should iterate over all elements in a nested array', function () {
+    const array = [[1, 2], [3, [4, 5]]]
+    const result = []
+    deepForEach(array, value => result.push(value))
+    assert.deepStrictEqual(result, [1, 2, 3, 4, 5])
+  })
+
+  it('should iterate over all elements in a mixed type array', function () {
+    const array = [1, 'two', [3, null, undefined, true]]
+    const result = []
+    deepForEach(array, value => result.push(value))
+    assert.deepStrictEqual(result, [1, 'two', 3, null, undefined, true])
+  })
+
+  it('should handle an empty array', function () {
+    const array = []
+    const result = []
+    deepForEach(array, value => result.push(value))
+    assert.deepStrictEqual(result, [])
+  })
+
+  it('should handle an array with empty nested arrays', function () {
+    const array = [[], [1, []], [2, [3, []]]]
+    const result = []
+    deepForEach(array, value => result.push(value))
+    assert.deepStrictEqual(result, [1, 2, 3])
+  })
+
+  it('should iterate over all elements in a DenseMatrix', function () {
+    const matrix = new DenseMatrix([[1, 2], [3, 4]])
+    const result = []
+    deepForEach(matrix, value => result.push(value))
+    assert.deepStrictEqual(result, [1, 2, 3, 4])
+  })
+
+  it('should call the callback with each element of a matrix after converting to array', function () {
+    const matrix = math.matrix([[1, 2], [3, 4]])
+    const result = []
+    deepForEach(matrix, value => result.push(value))
+    assert.deepStrictEqual(result, [1, 2, 3, 4])
+  })
+
+  it('should work with arrays containing complex numbers', function () {
+    const array = [math.complex(2, 3), [math.complex(4, 5)]]
+    const result = []
+    deepForEach(array, value => result.push(value))
+    assert.deepStrictEqual(result, [math.complex(2, 3), math.complex(4, 5)])
+  })
+})

--- a/tools/docgenerator.js
+++ b/tools/docgenerator.js
@@ -378,7 +378,7 @@ function validateDoc (doc) {
   const issues = []
 
   function ignore (field) {
-    return IGNORE_WARNINGS[field].indexOf(doc.name) !== -1
+    return IGNORE_WARNINGS[field].includes(doc.name)
   }
 
   if (!doc.name) {
@@ -558,10 +558,10 @@ function collectDocs (functionNames, inputPath) {
     let category
 
     // Note: determining whether a file is a function and what it's category
-    // is is a bit tricky and quite specific to the structure of the code,
+    // is a bit tricky and quite specific to the structure of the code,
     // we reckon with some edge cases here.
-    if (path.indexOf('docs') === -1 && functionIndex !== -1) {
-      if (path.indexOf('expression') !== -1) {
+    if (!path.includes('docs') && functionIndex !== -1) {
+      if (path.includes('expression')) {
         category = 'expression'
       } else if (/\/lib\/cjs\/type\/[a-zA-Z0-9_]*\/function/.test(fullPath)) {
         // for type/bignumber/function/bignumber.js, type/fraction/function/fraction.js, etc
@@ -579,7 +579,7 @@ function collectDocs (functionNames, inputPath) {
       category = 'construction'
     }
 
-    if (functionNames.indexOf(name) === -1 || IGNORE_FUNCTIONS[name]) {
+    if (!functionNames.includes(name) || IGNORE_FUNCTIONS[name]) {
       category = null
     }
 
@@ -601,7 +601,7 @@ function collectDocs (functionNames, inputPath) {
     const fn = functions[name]
     const code = String(fs.readFileSync(fn.fullPath))
 
-    const isFunction = (functionNames.indexOf(name) !== -1) && !IGNORE_FUNCTIONS[name]
+    const isFunction = (functionNames.includes(name)) && !IGNORE_FUNCTIONS[name]
     const doc = isFunction ? generateDoc(name, code) : null
 
     if (isFunction && doc) {

--- a/tools/entryGenerator.js
+++ b/tools/entryGenerator.js
@@ -266,7 +266,7 @@ function generateDependenciesFiles ({ suffix, factories, entryFolder }) {
 function generateFunctionsFiles ({ suffix, factories, entryFolder }) {
   const braceOpen = '{' // a hack to be able to create a single brace open character in handlebars
 
-  const sortedFactories = sortFactories(values(factories))
+  const sortedFactories = sortFactories(Object.values(factories))
 
   // sort the factories, and split them in three groups:
   // - transform: the transform functions
@@ -281,9 +281,9 @@ function generateFunctionsFiles ({ suffix, factories, entryFolder }) {
       if (isTransform(factory)) {
         transformFactories.push(factory)
       } else if (
-        contains(factory.dependencies, 'math') ||
-        contains(factory.dependencies, 'mathWithTransform') ||
-        contains(factory.dependencies, 'classes') ||
+        factory.dependencies.includes('math') ||
+        factory.dependencies.includes( 'mathWithTransform') ||
+        factory.dependencies.includes( 'classes') ||
         isTransform(factory) ||
         factory.dependencies.some(dependency => {
           return impureFactories.find(f => f.fn === stripOptionalNotation(dependency))
@@ -531,14 +531,6 @@ function sortFactories (factories) {
   }
 
   return sortedFactories
-}
-
-function values (object) {
-  return Object.keys(object).map(key => object[key])
-}
-
-function contains (array, item) {
-  return array.indexOf(item) !== -1
 }
 
 function isTransform (factory) {

--- a/tools/entryGenerator.js
+++ b/tools/entryGenerator.js
@@ -221,7 +221,7 @@ function generateDependenciesFiles ({ suffix, factories, entryFolder }) {
           .filter(dependency => !IGNORED_DEPENDENCIES[dependency])
           .filter(dependency => {
             if (!exists[dependency]) {
-              if (factory.dependencies.indexOf(dependency) !== -1) {
+              if (factory.dependencies.includes(dependency)) {
                 throw new Error(`Required dependency "${dependency}" missing for factory "${factory.fn}" (suffix: ${suffix})`)
               }
 
@@ -348,7 +348,7 @@ function generateFunctionsFiles ({ suffix, factories, entryFolder }) {
           .filter(dependency => {
             // TODO: this code is duplicated. extract it in a separate function
             if (!pureExists[dependency]) {
-              if (factory.dependencies.indexOf(dependency) !== -1) {
+              if (factory.dependencies.includes(dependency)) {
                 throw new Error(`Required dependency "${dependency}" missing for factory "${factory.fn}" (suffix: ${suffix})`)
               }
 
@@ -381,7 +381,7 @@ function generateFunctionsFiles ({ suffix, factories, entryFolder }) {
 
             // TODO: this code is duplicated. extract it in a separate function
             if (!impureExists[dependency]) {
-              // if (factory.dependencies.indexOf(dependency) !== -1) {
+              // if (factory.dependencies.includes(dependency)) {
               //   throw new Error(`Required dependency "${dependency}" missing for factory "${factory.fn}"`)
               // }
 
@@ -414,7 +414,7 @@ function generateFunctionsFiles ({ suffix, factories, entryFolder }) {
 
             // TODO: this code is duplicated. extract it in a separate function
             if (!impureExists[dependency]) {
-              // if (factory.dependencies.indexOf(dependency) !== -1) {
+              // if (factory.dependencies.includes(dependency)) {
               //   throw new Error(`Required dependency "${dependency}" missing for factory "${factory.fn}"`)
               // }
 

--- a/tools/matrixmarket.js
+++ b/tools/matrixmarket.js
@@ -37,27 +37,27 @@ const _importFromStream = function (stream) {
         const datatype = matches[3]
         const qualifier = matches[4]
         // check typecode
-        if (typecodes.indexOf(typecode) === -1) {
+        if (!typecodes.includes(typecode)) {
           // typecode not supported
           reject(new Error('Matrix Market type code is not supported: ' + typecode))
           // close stream
           stream.close()
         }
         // check format
-        if (formats.indexOf(format) === -1) {
+        if (!formats.includes(format)) {
           // typecode not supported
           reject(new Error('Matrix Market format is not supported: ' + format))
           // close stream
           stream.close()
         }
         // check datatype
-        if (datatypes.indexOf(datatype) === -1) {
+        if (!datatypes.includes(datatype)) {
           // typecode not supported
           reject(new Error('Matrix Market datatype is not supported: ' + datatype))
           // close stream
           stream.close()
         }
-        if (qualifiers.indexOf(qualifier) === -1) {
+        if (!qualifiers.includes(qualifier)) {
           // typecode not supported
           reject(new Error('Matrix Market qualifier is not supported: ' + qualifier))
           // close stream

--- a/types/EXPLANATION.md
+++ b/types/EXPLANATION.md
@@ -1,6 +1,6 @@
 # Mathjs TypeScript types
 
-The code base of Mathjs is writting in JavaScript. The TypeScript definitions are maintained separately. 
+The code base of Mathjs is written in JavaScript. The TypeScript definitions are maintained separately. 
 
 ## Library structure
 
@@ -51,4 +51,16 @@ export const {
   addDependencies,
   // ...
 } : Record<string, FactoryFunctionMap>
+```
+
+## Testing the type definitions
+
+The types are defined in `types/index.d.ts`.
+
+The tests for the type definitions are located in `test/typescript-types/testTypes.ts`.
+
+To run the tests for the type definitions:
+
+```
+npm run test:types
 ```

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2806,6 +2806,19 @@ export interface MathJsInstance extends MathJsFactory {
   prod(A: MathCollection): MathScalarType
 
   /**
+   * @param A A single matrix
+   * @param probOrN prob is the order of the quantile, while N is the
+   * amount of evenly distributed steps of probabilities; only one of
+   * these options can be provided
+   * @param sorted =false is data sorted in ascending order
+   * @returns Quantile(s)
+   */
+  quantileSeq<T extends MathScalarType>(
+    A: T[] | T[][],
+    prob: number | BigNumber | MathArray,
+    sorted?: boolean
+  ): T
+  /**
    * Compute the prob order quantile of a matrix or a list with values.
    * The sequence is sorted and the middle value is returned. Supported
    * types of sequence values are: Number, BigNumber, Unit Supported types
@@ -2823,7 +2836,7 @@ export interface MathJsInstance extends MathJsFactory {
     A: MathCollection,
     prob: number | BigNumber | MathArray,
     sorted?: boolean
-  ): number | BigNumber | Unit | MathArray
+  ): MathScalarType | MathArray
 
   /**
    * Compute the standard deviation of a matrix or a list with values. The


### PR DESCRIPTION
### **PR Type**
enhancement, bug fix, documentation, tests


___

### **Description**
- Replaced custom `contains` function and `indexOf` usage with native `includes` for array and string checks.
- Fixed serialization of Units without a value.
- Improved type definitions for `quantileSeq` function.
- Added tests for `deepForEach` utility function.
- Added tests for Unit serialization and deserialization.
- Corrected documentation for operator precedence.
- Updated history with recent changes and fixes.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><details><summary>19 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>cli.js</strong><dd><code>Use `includes` instead of `indexOf` for array checks.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
bin/cli.js

- Replaced `indexOf` with `includes` for array checks.



</details>
    

  </td>
  <td><a href="https://github.com/chaelimheo/mathjs/pull/1/files#diff-ca900686fca4680d4692bf587dc5da1322879c344688c187b5511cda27902c18">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>config.js</strong><dd><code>Replace custom `contains` function with native `includes`.</code></dd></summary>
<hr>
      
src/core/function/config.js

<li>Removed the <code>contains</code> utility function.<br> <li> Replaced <code>contains</code> with <code>includes</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/chaelimheo/mathjs/pull/1/files#diff-090e2e9b9ba8bbd8750b7cc4fc79541640e3e97fe24cef5cfe9d02734f91bd1e">+1/-11</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>import.js</strong><dd><code>Replace `contains` with native `includes` in import functions.</code></dd></summary>
<hr>
      
src/core/function/import.js

<li>Removed the <code>contains</code> import.<br> <li> Replaced <code>contains</code> with <code>includes</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/chaelimheo/mathjs/pull/1/files#diff-f612ccbefaff0508545660dfdd07dd044193e9e0e958a6df30f069c4d5b22bc2">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>parse.js</strong><dd><code>Improve function names and use `includes` for array checks.</code></dd></summary>
<hr>
      
src/expression/parse.js

<li>Updated function names and comments for clarity.<br> <li> Replaced <code>indexOf</code> with <code>includes</code> for array checks.<br>


</details>
    

  </td>
  <td><a href="https://github.com/chaelimheo/mathjs/pull/1/files#diff-cc1ffef9ac1457adf652aefd10f7add0dd36a30d4c36adbf1b07d555e418e785">+8/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>derivative.js</strong><dd><code>Use `includes` instead of `indexOf` for array checks.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/function/algebra/derivative.js

- Replaced `indexOf` with `includes` for array checks.



</details>
    

  </td>
  <td><a href="https://github.com/chaelimheo/mathjs/pull/1/files#diff-7dd51e69689a1f72423aa3845f12a85f8ff7f6e07f74bb5ade8c5292186f9897">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rationalize.js</strong><dd><code>Use `includes` instead of `indexOf` for array checks.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/function/algebra/rationalize.js

- Replaced `indexOf` with `includes` for array checks.



</details>
    

  </td>
  <td><a href="https://github.com/chaelimheo/mathjs/pull/1/files#diff-f2e5332c5f3b645e0bf5e3181f726d81ece6e230f99d7c0405472dca307a3c25">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>simplifyConstant.js</strong><dd><code>Use `includes` instead of `indexOf` for array checks.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/function/algebra/simplifyConstant.js

- Replaced `indexOf` with `includes` for array checks.



</details>
    

  </td>
  <td><a href="https://github.com/chaelimheo/mathjs/pull/1/files#diff-323a439331a949485110e5df4836a2593b218aa131c9082597d56b1f64b7580e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mad.js</strong><dd><code>Use `includes` instead of `indexOf` for error message checks.</code></dd></summary>
<hr>
      
src/function/statistics/mad.js

- Replaced `indexOf` with `includes` for error message checks.



</details>
    

  </td>
  <td><a href="https://github.com/chaelimheo/mathjs/pull/1/files#diff-7e88e02769cd6516dc3aae865f8b75c59dbf13d98595f4b6e0f8352919fac749">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>std.js</strong><dd><code>Use `includes` instead of `indexOf` for error message checks.</code></dd></summary>
<hr>
      
src/function/statistics/std.js

- Replaced `indexOf` with `includes` for error message checks.



</details>
    

  </td>
  <td><a href="https://github.com/chaelimheo/mathjs/pull/1/files#diff-1cecbdf972c4deae942b09f6866ab61e187067528f5b97f166acec4ad2fadca2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>improveErrorMessage.js</strong><dd><code>Use `includes` instead of `indexOf` for error message checks.</code></dd></summary>
<hr>
      
src/function/statistics/utils/improveErrorMessage.js

- Replaced `indexOf` with `includes` for error message checks.



</details>
    

  </td>
  <td><a href="https://github.com/chaelimheo/mathjs/pull/1/files#diff-7ac9c1a6aa22408437676f2fd7fc3db89627cad8e69395febcafa312145c9d11">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>array.js</strong><dd><code>Remove custom `contains` utility function.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/utils/array.js

- Removed the `contains` utility function.



</details>
    

  </td>
  <td><a href="https://github.com/chaelimheo/mathjs/pull/1/files#diff-1aa5621ac030273c31fbfcdc66721c027625782b0b997c6613d1a76b05b78b46">+0/-10</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>formatter.js</strong><dd><code>Use `includes` instead of `indexOf` for string checks.</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/utils/bignumber/formatter.js

- Replaced `indexOf` with `includes` for string checks.



</details>
    

  </td>
  <td><a href="https://github.com/chaelimheo/mathjs/pull/1/files#diff-adacd3669b2de5e8260488f159d31b34711ccc5863f7e682ac1d1781ca0c46c2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>factory.js</strong><dd><code>Replace `contains` with native `includes` in factory functions.</code></dd></summary>
<hr>
      
src/utils/factory.js

<li>Removed the <code>contains</code> import.<br> <li> Replaced <code>contains</code> with <code>includes</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/chaelimheo/mathjs/pull/1/files#diff-2a9fdf18ad8d99dd53343b48d022ddf9ff2d5dee70dd510171f26e238f196d71">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>object.js</strong><dd><code>Use `includes` instead of `indexOf` for string checks.</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/utils/object.js

- Replaced `indexOf` with `includes` for string checks.



</details>
    

  </td>
  <td><a href="https://github.com/chaelimheo/mathjs/pull/1/files#diff-7a0b37e348229f59e58ee25ac2e8d6b32fa65bf335c0bcb83fddcb79d3a1f81e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>snapshot.js</strong><dd><code>Use `includes` instead of `indexOf` for string checks.</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/utils/snapshot.js

- Replaced `indexOf` with `includes` for string checks.



</details>
    

  </td>
  <td><a href="https://github.com/chaelimheo/mathjs/pull/1/files#diff-d08ab25feaac0470a5f1bc1606b12db083f3b732b25a8e58d6748bdd9002ec2e">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>docgenerator.js</strong><dd><code>Use `includes` instead of `indexOf` for array checks.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
tools/docgenerator.js

- Replaced `indexOf` with `includes` for array checks.



</details>
    

  </td>
  <td><a href="https://github.com/chaelimheo/mathjs/pull/1/files#diff-eaa0487d420873fc247b9c758700fc6a49587c381d06163313355661c2efb15d">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>entryGenerator.js</strong><dd><code>Use `includes` and `Object.values` for array and object checks.</code></dd></summary>
<hr>
      
tools/entryGenerator.js

<li>Replaced <code>indexOf</code> with <code>includes</code> for array checks.<br> <li> Replaced <code>values</code> function with <code>Object.values</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/chaelimheo/mathjs/pull/1/files#diff-5d94625434064a902364a6f3a2e88973c8c1bbc7921ffaefd312c5da3fd3ab4f">+8/-16</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>matrixmarket.js</strong><dd><code>Use `includes` instead of `indexOf` for array checks.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
tools/matrixmarket.js

- Replaced `indexOf` with `includes` for array checks.



</details>
    

  </td>
  <td><a href="https://github.com/chaelimheo/mathjs/pull/1/files#diff-d9f5ca78c922ab6e4a50a9ae7ff3eccff472a0ff3d13471365e933c2b02ae6b2">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.d.ts</strong><dd><code>Improve type definitions for `quantileSeq` function.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
types/index.d.ts

- Improved type definitions for `quantileSeq` function.



</details>
    

  </td>
  <td><a href="https://github.com/chaelimheo/mathjs/pull/1/files#diff-093ad82a25aee498b11febf1cdcb6546e4d223ffcb49ed69cc275ac27ce0ccce">+14/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Bug fix
</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>Unit.js</strong><dd><code>Fix serialization of Units without a value.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/type/unit/Unit.js

- Fixed serialization of Units without a value.



</details>
    

  </td>
  <td><a href="https://github.com/chaelimheo/mathjs/pull/1/files#diff-0916f5ce91877818921dc4ed46b51a8c21daa25f44c75c1b401c9be52c2b603e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests
</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>browser.test.js</strong><dd><code>Use `includes` instead of `indexOf` for array checks.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
test/node-tests/browser.test.js

- Replaced `indexOf` with `includes` for array checks.



</details>
    

  </td>
  <td><a href="https://github.com/chaelimheo/mathjs/pull/1/files#diff-fc2209b3d1d1a75fa1c027d8f38fee0d7b78eebf687835a9c6da248bb8047576">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>doc.test.js</strong><dd><code>Use `includes` instead of `indexOf` for array checks.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
test/node-tests/doc.test.js

- Replaced `indexOf` with `includes` for array checks.



</details>
    

  </td>
  <td><a href="https://github.com/chaelimheo/mathjs/pull/1/files#diff-5b2d21f5fcafbf49e410e2398a7fb9133a4d44f5a6ea7b966235cd33ea208109">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>replacer.test.js</strong><dd><code>Add tests for Unit serialization.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
test/unit-tests/json/replacer.test.js

- Added tests for Unit serialization with and without values.



</details>
    

  </td>
  <td><a href="https://github.com/chaelimheo/mathjs/pull/1/files#diff-645640081edd5e2a928b1125fe5a2153afa90a55c2a73ac110e9f349f02c1fb5">+14/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>reviver.test.js</strong><dd><code>Add tests for Unit deserialization.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
test/unit-tests/json/reviver.test.js

- Added tests for Unit deserialization with and without values.



</details>
    

  </td>
  <td><a href="https://github.com/chaelimheo/mathjs/pull/1/files#diff-ec6cc98e222b432ca4c02ba26d5c3845606f1e9da3443e882fbe73bc6825b5a8">+20/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>deepForEach.test.js</strong><dd><code>Add tests for `deepForEach` utility function.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
test/unit-tests/type/matrix/utils/deepForEach.test.js

- Added tests for `deepForEach` utility function.



</details>
    

  </td>
  <td><a href="https://github.com/chaelimheo/mathjs/pull/1/files#diff-29decdafb1b5076304394fcfaf4add7612dbc5d89a9efefea4b578e4d867ada7">+63/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>testTypes.ts</strong><dd><code>Add tests for `quantileSeq` function return types.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
test/typescript-tests/testTypes.ts

- Added tests for `quantileSeq` function return types.



</details>
    

  </td>
  <td><a href="https://github.com/chaelimheo/mathjs/pull/1/files#diff-66424e9e2afdbff8a82b370e67fe043e56f02224e48d346862a91c50b4b6978b">+13/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Documentation
</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>HISTORY.md</strong><dd><code>Update HISTORY.md with recent changes.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
HISTORY.md

- Updated history with recent changes and fixes.



</details>
    

  </td>
  <td><a href="https://github.com/chaelimheo/mathjs/pull/1/files#diff-648afe3d986261d8f2015b2b131b0e4a448d4dc6946cfde1a7a836876cee255e">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add instructions for testing type definitions.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
README.md

- Added instructions for testing type definitions.



</details>
    

  </td>
  <td><a href="https://github.com/chaelimheo/mathjs/pull/1/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>syntax.md</strong><dd><code>Correct documentation for operator precedence.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
docs/expressions/syntax.md

- Corrected documentation for operator precedence.



</details>
    

  </td>
  <td><a href="https://github.com/chaelimheo/mathjs/pull/1/files#diff-e4d65ba75568bb0eca18536f7f34bec7c215e708c1d92e22d6c76436bcdf8d92">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>EXPLANATION.md</strong><dd><code>Fix typo and add type definition testing instructions.</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
types/EXPLANATION.md

- Fixed typo and added instructions for testing type definitions.



</details>
    

  </td>
  <td><a href="https://github.com/chaelimheo/mathjs/pull/1/files#diff-8de1b1c38d5fc122f9e9cfa8648a2b7f023463e7e84a831b58c855c0cb0cfda2">+13/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

